### PR TITLE
Add luacheck

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,0 +1,13 @@
+name: luacheck
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: apt
+      run: sudo apt-get install -y luarocks
+    - name: luacheck install
+      run: luarocks install --local luacheck
+    - name: luacheck run
+      run: $HOME/.luarocks/bin/luacheck ./

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,16 @@
+unused_args = false
+
+globals = {
+    "minetest",
+	"signs_lib",
+}
+
+read_globals = {
+	-- Builtin
+	table = {fields = {"copy"}},
+	"ItemStack", "vector",
+	
+	-- Mod deps
+	"intllib",
+	"screwdriver",
+}

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,5 @@
 unused_args = false
+max_line_length = 180
 
 globals = {
     "minetest",

--- a/encoding.lua
+++ b/encoding.lua
@@ -278,7 +278,7 @@ function signs_lib.Utf8ToAnsi(s)
 			if scope[b] then
 				scope = scope[b]
 				if "string" == type(scope) then
-					r, scope = r .. scope
+					r, scope = r .. scope, nil
 					j = -1 -- supress general UTF-8 parser
 				end
 			else
@@ -290,11 +290,11 @@ function signs_lib.Utf8ToAnsi(s)
 
 		-- general UTF-8 parser
 		if j == -1 then -- supressed by legacy parser
-			j, l, u = nil
+			j = nil
 		elseif b < 0x80 then
 			if j then
 				r = r .. "&#ufffd;"
-				j, l, u = nil
+				j = nil
 			end
 			-- ASCII handled by legacy parser
 		elseif b >= 0xc0 then
@@ -304,7 +304,7 @@ function signs_lib.Utf8ToAnsi(s)
 			j = i
 			if b >= 0xf8 then
 				r = r .. "&#ufffd;"
-				j, l, u = nil
+				j = nil
 			elseif b >= 0xf0 then
 				l, u = 4, b % (2 ^ 3)
 			elseif b >= 0xe0 then
@@ -317,7 +317,7 @@ function signs_lib.Utf8ToAnsi(s)
 				u = u * (2 ^ 6) + b % (2 ^ 6)
 				if i == j + l - 1 then
 					r = r .. string.format("&#u%x;", u)
-					j, l, u = nil
+					j = nil
 				end
 			else
 				r = r .. "&#ufffd;"

--- a/encoding.lua
+++ b/encoding.lua
@@ -237,7 +237,7 @@ local nmdc = {
 	[124] = "|"
 }
 
-function AnsiToUtf8(s)
+function signs_lib.AnsiToUtf8(s)
 	local r, b = ""
 	for i = 1, s and s:len() or 0 do
 		b = s:byte(i)
@@ -258,7 +258,7 @@ function AnsiToUtf8(s)
 	return r
 end
 
-function Utf8ToAnsi(s)
+function signs_lib.Utf8ToAnsi(s)
 	local r, b = ""
 	local scope
 	local j, l, u

--- a/init.lua
+++ b/init.lua
@@ -7,7 +7,7 @@ signs_lib = {}
 
 signs_lib.path = minetest.get_modpath(minetest.get_current_modname())
 
-local S, NS = dofile(signs_lib.path .. "/intllib.lua")
+local S = dofile(signs_lib.path .. "/intllib.lua")
 signs_lib.gettext = S
 
 dofile(signs_lib.path.."/encoding.lua")


### PR DESCRIPTION
Added luacheck and fixed most of the warnings, but there's a few harder ones to fix.

- [ ] Line length warnings: (could change `max_line_length` to 180, but better to fix them)
```
api.lua:499:121: line is too long (146 > 120)
api.lua:700:121: line is too long (133 > 120)
api.lua:705:121: line is too long (157 > 120)
api.lua:920:121: line is too long (123 > 120)
api.lua:1074:121: line is too long (124 > 120)
api.lua:1119:121: line is too long (131 > 120)
api.lua:1122:121: line is too long (146 > 120)
api.lua:1149:121: line is too long (129 > 120)
api.lua:1246:121: line is too long (177 > 120)
api.lua:1270:121: line is too long (131 > 120)
```

- [x] Assignment warnings:
```
encoding.lua:281:6: right side of assignment has less values than left side expects
encoding.lua:293:4: right side of assignment has less values than left side expects
encoding.lua:297:5: right side of assignment has less values than left side expects
encoding.lua:307:5: right side of assignment has less values than left side expects
encoding.lua:320:6: right side of assignment has less values than left side expects
```

https://github.com/mt-mods/signs_lib/blob/3f1a8fa3f25a17bc33f700bb249627d3f11c7f8d/encoding.lua#L281

@syimyuzya what is intended with those assignments? Should both variables be assigned the value, or only one?