### PR TITLE
Fix some warnings from #3

### DIFF
--- a/encoding.lua
+++ b/encoding.lua
@@ -278,7 +278,7 @@ function signs_lib.Utf8ToAnsi(s)
 			if scope[b] then
 				scope = scope[b]
 				if "string" == type(scope) then
-					r, scope = r .. scope
+					r, scope = r .. scope, nil
 					j = -1 -- supress general UTF-8 parser
 				end
 			else
@@ -290,11 +290,11 @@ function signs_lib.Utf8ToAnsi(s)
 
 		-- general UTF-8 parser
 		if j == -1 then -- supressed by legacy parser
-			j, l, u = nil
+			j = nil
 		elseif b < 0x80 then
 			if j then
 				r = r .. "&#ufffd;"
-				j, l, u = nil
+				j = nil
 			end
 			-- ASCII handled by legacy parser
 		elseif b >= 0xc0 then
@@ -304,7 +304,7 @@ function signs_lib.Utf8ToAnsi(s)
 			j = i
 			if b >= 0xf8 then
 				r = r .. "&#ufffd;"
-				j, l, u = nil
+				j = nil
 			elseif b >= 0xf0 then
 				l, u = 4, b % (2 ^ 3)
 			elseif b >= 0xe0 then
@@ -317,7 +317,7 @@ function signs_lib.Utf8ToAnsi(s)
 				u = u * (2 ^ 6) + b % (2 ^ 6)
 				if i == j + l - 1 then
 					r = r .. string.format("&#u%x;", u)
-					j, l, u = nil
+					j = nil
 				end
 			else
 				r = r .. "&#ufffd;"


### PR DESCRIPTION
In #3:

> https://github.com/mt-mods/signs_lib/blob/3f1a8fa3f25a17bc33f700bb249627d3f11c7f8d/encoding.lua#L281
>
> @syimyuzya what is intended with those assignments? Should both variables be assigned the value, or only one?

This piece of code existed before my modification, It is equivalent to (and should be written as) `r, scope = r .. scope, nil`.

I immitated this style at first in my code, writing `j, l, u = nil` four times. Didn't realize that this is not actually a good practice in Lua. This can be fixed by changing to just `j = nil` (`l` and `u` not read when `j` is `nil`).