### PR TITLE
add setting for custom edit priv

### DIFF
--- a/API.md
+++ b/API.md
@@ -250,7 +250,7 @@ signs_lib.register_sign("basic_signs:sign_wall_glass", {
 
 * `signs_lib.rightclick_sign(pos, node, player, itemstack, pointed_thing)`
 
-  Open the default sign formspec, if the player has the `signslib_edit` privilege.
+  Open the default sign formspec, if the player has the `signslib_edit` privilege. (privilege can be set by `signs_lib.edit_priv` setting)
 
 * `signs_lib.destruct_sign(pos)`
 

--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ The list of loaded, sign-bearing blocks is created/populated by an LBM (and trim
 * `signslib_edit`
 
 Allows to rotate signs and to open (and consequently edit) any default sign formspec.
+(privilege can be set by `signs_lib.edit_priv` setting)

--- a/api.lua
+++ b/api.lua
@@ -1294,7 +1294,7 @@ minetest.register_chatcommand("regen_signs", {
 
 minetest.register_on_mods_loaded(function()
 	if not minetest.registered_privileges[signs_lib.edit_priv] then
-        minetest.register_privilege("signslib_edit", {})
+    	minetest.register_privilege("signslib_edit", {})
 	end
 end)
 

--- a/api.lua
+++ b/api.lua
@@ -1294,7 +1294,7 @@ minetest.register_chatcommand("regen_signs", {
 
 minetest.register_on_mods_loaded(function()
 	if not minetest.registered_privileges[signs_lib.edit_priv] then
-    	minetest.register_privilege("signslib_edit", {})
+		minetest.register_privilege("signslib_edit", {})
 	end
 end)
 

--- a/api.lua
+++ b/api.lua
@@ -812,7 +812,7 @@ function signs_lib.can_modify(pos, player)
 
 	if owner == ""
 	  or playername == owner
-	  or (minetest.check_player_privs(playername, {signslib_edit=true}))
+	  or minetest.get_player_privs(playername)[signs_lib.edit_priv]
 	  or (playername == minetest.settings:get("name")) then
 		return true
 	end
@@ -1292,7 +1292,11 @@ minetest.register_chatcommand("regen_signs", {
 	end
 })
 
-minetest.register_privilege("signslib_edit", {})
+minetest.register_on_mods_loaded(function()
+	if not minetest.registered_privileges[signs_lib.edit_priv] then
+        minetest.register_privilege("signslib_edit", {})
+	end
+end)
 
 
 

--- a/init.lua
+++ b/init.lua
@@ -9,6 +9,8 @@ signs_lib.path = minetest.get_modpath(minetest.get_current_modname())
 
 signs_lib.S = minetest.get_translator(minetest.get_current_modname())
 
+signs_lib.edit_priv = minetest.settings:get("signs_lib.edit_priv") or "signslib_edit"
+
 dofile(signs_lib.path.."/encoding.lua")
 dofile(signs_lib.path.."/api.lua")
 dofile(signs_lib.path.."/standard_signs.lua")

--- a/settingstypes.txt
+++ b/settingstypes.txt
@@ -1,0 +1,1 @@
+signs_lib.edit_priv (Allows to rotate signs and to open (and consequently edit) any default sign formspec) string signslib_edit


### PR DESCRIPTION
`signs_lib.edit_priv` can be set by `signs_lib.edit_priv` setting (see settingtypes.txt)

Hopefully enough documentation?