### PR TITLE
don't emit translation strings to the log

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -1,11 +1,10 @@
 -- signs_lib api, backported from street_signs
 
-local f = string.format
 local S = signs_lib.S
 local has_default_mod = minetest.get_modpath("default")
 
 local function log(level, messagefmt, ...)
-	minetest.log(level, "[signs_lib] " .. f(messagefmt, ...))
+	minetest.log(level, "[signs_lib] " .. messagefmt:format(...))
 end
 
 local function get_sign_formspec() end

--- a/api.lua
+++ b/api.lua
@@ -1,7 +1,12 @@
 -- signs_lib api, backported from street_signs
 
+local f = string.format
 local S = signs_lib.S
 local has_default_mod = minetest.get_modpath("default")
+
+local function log(level, messagefmt, ...)
+	minetest.log(level, "[signs_lib] " .. f(messagefmt, ...))
+end
 
 local function get_sign_formspec() end
 
@@ -973,7 +978,7 @@ function signs_lib.after_place_node(pos, placer, itemstack, pointed_thing, locke
 end
 
 function signs_lib.register_fence_with_sign()
-	minetest.log("warning", "[signs_lib] ".."Attempt to call no longer used function signs_lib.register_fence_with_sign()")
+	log("warning", "[signs_lib] Attempt to call no longer used function signs_lib.register_fence_with_sign()")
 end
 
 local use_glow = function(pos, node, puncher, pointed_thing)
@@ -1364,11 +1369,11 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 	local playername = player:get_player_name()
 
 	if fields.text and fields.ok then
-		minetest.log("action", S("@1 wrote \"@2\" to sign at @3",
+		log("action", "%s wrote %q to sign at %s",
 			(playername or ""),
-			fields.text:gsub('\\', '\\\\'):gsub("\n", "\\n"),
+			fields.text:gsub("\n", "\\n"),
 			pos_string
-		))
+		)
 		signs_lib.update_sign(pos, fields)
 	elseif fields.wide_on or fields.wide_off or fields.uni_on or fields.uni_off then
 		local node = minetest.get_node(pos)
@@ -1392,20 +1397,20 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		end
 
 		if change_wide then
-			minetest.log("action", S("@1 flipped the wide-font switch to \"@2\" at @3",
+			log("action", "%s flipped the wide-font switch to %q at %s",
 				(playername or ""),
 				(fields.wide_on and "off" or "on"),
 				minetest.pos_to_string(pos)
-			))
+			)
 			signs_lib.update_sign(pos, fields)
 			minetest.show_formspec(playername, "signs_lib:sign", get_sign_formspec(pos, node.name))
 		end
 		if change_uni then
-			minetest.log("action", S("@1 flipped the unicode-font switch to \"@2\" at @3",
+			log("action", "%s flipped the unicode-font switch to %q at %s",
 				(playername or ""),
 				(fields.uni_on and "off" or "on"),
 				minetest.pos_to_string(pos)
-			))
+			)
 			signs_lib.update_sign(pos, fields)
 			minetest.show_formspec(playername, "signs_lib:sign", get_sign_formspec(pos, node.name))
 		end

--- a/api.lua
+++ b/api.lua
@@ -977,7 +977,7 @@ function signs_lib.after_place_node(pos, placer, itemstack, pointed_thing, locke
 end
 
 function signs_lib.register_fence_with_sign()
-	log("warning", "[signs_lib] Attempt to call no longer used function signs_lib.register_fence_with_sign()")
+	log("warning", "Attempt to call no longer used function signs_lib.register_fence_with_sign()")
 end
 
 local use_glow = function(pos, node, puncher, pointed_thing)


### PR DESCRIPTION
they are not useful there and interfere w/ the usual means of searching through logs.