### PR TITLE
Make missing strings translatable, update locale files and German

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -1,6 +1,7 @@
 -- signs_lib api, backported from street_signs
 
 local S = signs_lib.S
+local FS = function(...) return minetest.formspec_escape(S(...)) end
 local has_default_mod = minetest.get_modpath("default")
 
 local function log(level, messagefmt, ...)
@@ -1278,7 +1279,7 @@ minetest.register_lbm({
 minetest.register_chatcommand("regen_signs", {
 	params = "",
 	privs = {server = true},
-	description = "Skims through all currently-loaded sign-bearing mapblocks, clears away any entities within each sign's node space, and regenerates their text entities, if any.",
+	description = S("Skims through all currently-loaded sign-bearing mapblocks, clears away any entities within each sign's node space, and regenerates their text entities, if any."),
 	func = function(player_name, params)
 		local allsigns = {}
 		local totalsigns = 0
@@ -1297,13 +1298,13 @@ minetest.register_chatcommand("regen_signs", {
 		end
 		if signs_lib.totalblocks < 0 then signs_lib.totalblocks = 0 end
 		if totalsigns == 0 then
-			minetest.chat_send_player(player_name, "There are no signs in the currently-loaded terrain.")
+			minetest.chat_send_player(player_name, S("There are no signs in the currently-loaded terrain."))
 			signs_lib.block_list = {}
 			return
 		end
 
-		minetest.chat_send_player(player_name, "Found a total of "..totalsigns.." sign nodes across "..signs_lib.totalblocks.." blocks.")
-		minetest.chat_send_player(player_name, "Regenerating sign entities...")
+		minetest.chat_send_player(player_name, S("Found a total of @1 sign nodes across @2 blocks.", totalsigns, signs_lib.totalblocks))
+		minetest.chat_send_player(player_name, S("Regenerating sign entities ..."))
 
 		for _, b in pairs(allsigns) do
 			for _, pos in ipairs(b) do
@@ -1315,7 +1316,7 @@ minetest.register_chatcommand("regen_signs", {
 				end
 			end
 		end
-		minetest.chat_send_player(player_name, "Finished.")
+		minetest.chat_send_player(player_name, S("Finished."))
 	end
 })
 
@@ -1343,14 +1344,14 @@ function get_sign_formspec(pos, nodename)
 		"image[0.1,2.4;7,1;signs_lib_sign_color_palette.png]",
 		"textarea[0.15,-0.2;6.3,2.8;text;;" .. minetest.formspec_escape(txt) .. "]",
 		"button_exit[3.7,3.4;2,1;ok;" .. S("Write") .. "]",
-		"label[0.3,3.4;Unicode font]",
+		"label[0.3,3.4;"..FS("Unicode font").."]",
 		"image_button[0.6,3.7;1,0.6;signs_lib_switch_" .. state .. ".png;uni_"
 			.. state .. ";;;false;signs_lib_switch_interm.png]",
 	}
 
 	if minetest.registered_nodes[nodename].allow_widefont then
 		state = meta:get_int("widefont") == 1 and "on" or "off"
-		formspec[#formspec+1] = "label[2.1,3.4;Wide font]"
+		formspec[#formspec+1] = "label[2.1,3.4;"..FS("Wide font").."]"
 		formspec[#formspec+1] = "image_button[2.3,3.7;1,0.6;signs_lib_switch_" .. state .. ".png;wide_"
 				.. state .. ";;;false;signs_lib_switch_interm.png]"
 	end

--- a/locale/signs_lib.de.tr
+++ b/locale/signs_lib.de.tr
@@ -1,12 +1,12 @@
 # textdomain: signs_lib
-Locked sign, owned by @1@n=gesperrter Schild, gehört @1@n
-Skims through all currently-loaded sign-bearing mapblocks, clears away any entities within each sign's node space, and regenerates their text entities, if any.=
-There are no signs in the currently-loaded terrain.=
-Found a total of @1 sign nodes across @2 blocks.=
-Regenerating sign entities ...=
-Finished.=
-Write=schreiben
-Unicode font=
-Wide font=
-Wooden Wall Sign=
-Steel Wall Sign=
+Locked sign, owned by @1@n=Abgeschlossenes Schild, gehört @1@n
+Skims through all currently-loaded sign-bearing mapblocks, clears away any entities within each sign's node space, and regenerates their text entities, if any.=Iteriert durch alle derzeit geladenen Kartenblöcke, die Schilder enthalten, löscht alle Entities innerhalb des Node-Raums eines jeden Schildes und erzeugt ihre Text-Entities, falls vorhanden, neu.
+There are no signs in the currently-loaded terrain.=Im derzeit geladenen Gelände befinden sich keine Schilder.
+Found a total of @1 sign nodes across @2 blocks.=Insgesamt wurden @1 Schild-Nodes über @2 Kartenblöcke gefunden.
+Regenerating sign entities ...=Schild-Entities werden neu erzeugt ...
+Finished.=Fertig.
+Write=Schreiben
+Unicode font=Unicode-Schrift
+Wide font=Weite Schrift
+Wooden Wall Sign=Holzwandschild
+Steel Wall Sign=Stahlwandschild

--- a/locale/signs_lib.de.tr
+++ b/locale/signs_lib.de.tr
@@ -1,27 +1,12 @@
 # textdomain: signs_lib
 Locked sign, owned by @1@n=gesperrter Schild, gehört @1@n
+Skims through all currently-loaded sign-bearing mapblocks, clears away any entities within each sign's node space, and regenerates their text entities, if any.=
+There are no signs in the currently-loaded terrain.=
+Found a total of @1 sign nodes across @2 blocks.=
+Regenerating sign entities ...=
+Finished.=
 Write=schreiben
-@1 wrote "@2" to sign at @3=
-@1 flipped the wide-font switch to "@2" at @3=
-@1 flipped the unicode-font switch to "@2" at @3=
-
-
-##### not used anymore #####
-
-locked =gesperrt 
-@1 wrote "@2" to @3sign at @4=@1 schrieb "@2" auf das @3Schild bei @4
-Sign=Schild
-Can edit all locked signs=Kann alle gesperrte Schilder bearbeiten
-Locked Sign=gesperrter Schild
-green=grün
-yellow=gelb
-red=rot
-white_red=weißrot
-white_black=schwarzweiß
-orange=orange
-blue=blau
-brown=braun
-Sign (@1, metal)=Schild (@1, Metall)
-Attempt to register unknown node as fence=Versuch ein unbekanntes Element als Zaun zu registrieren
-Registered @1 and @2=Registrierte @1 und @2
-[MOD] signs loaded=[MOD] Schilder-Mod geladen
+Unicode font=
+Wide font=
+Wooden Wall Sign=
+Steel Wall Sign=

--- a/locale/signs_lib.es.tr
+++ b/locale/signs_lib.es.tr
@@ -1,25 +1,12 @@
 # textdomain: signs_lib
 Locked sign, owned by @1@n=
+Skims through all currently-loaded sign-bearing mapblocks, clears away any entities within each sign's node space, and regenerates their text entities, if any.=
+There are no signs in the currently-loaded terrain.=
+Found a total of @1 sign nodes across @2 blocks.=
+Regenerating sign entities ...=
+Finished.=
 Write=
-@1 wrote "@2" to sign at @3=
-@1 flipped the wide-font switch to "@2" at @3=
-@1 flipped the unicode-font switch to "@2" at @3=
-
-
-##### not used anymore #####
-
-locked =bloqueada 
-@1 wrote "@2" to @3sign at @4=@1 escribio "@2" en el cartel @3en @4
-Sign=Letrero
-Locked Sign=Letrero bloqueada
-green=verde
-yellow=amarillo
-red=rojo
-white_red=rojo y blanco
-white_black=negro y blanco
-orange=naranja
-blue=azul
-brown=marrón
-Sign (@1, metal)=Letrero (@1, metal)
-Registered @1 and @2=Registrado @1 y @2
-[MOD] signs loaded=[MOD] signs cargados
+Unicode font=
+Wide font=
+Wooden Wall Sign=
+Steel Wall Sign=

--- a/locale/signs_lib.fr.tr
+++ b/locale/signs_lib.fr.tr
@@ -1,27 +1,12 @@
 # textdomain: signs_lib
 Locked sign, owned by @1@n=Panneau verrouillé, appartient à @1@n
+Skims through all currently-loaded sign-bearing mapblocks, clears away any entities within each sign's node space, and regenerates their text entities, if any.=
+There are no signs in the currently-loaded terrain.=
+Found a total of @1 sign nodes across @2 blocks.=
+Regenerating sign entities ...=
+Finished.=
 Write=
-@1 wrote "@2" to sign at @3=
-@1 flipped the wide-font switch to "@2" at @3=
-@1 flipped the unicode-font switch to "@2" at @3=
-
-
-##### not used anymore #####
-
-locked =verrouillé 
-@1 wrote "@2" to @3sign at @4=@1 a écrit "@2" sur le panneau @3en @4
-Sign=Panneau
-Can edit all locked signs=Peut modifier les panneaux verrouillés
-Locked Sign=Panneau (verrouillé)
-green=vert
-yellow=jaune
-red=rouge
-white_red=rouge et blanc
-white_black=noir et blanc
-orange=orange
-blue=bleu
-brown=marron
-Sign (@1, metal)=Panneau (@1, métal)
-Attempt to register unknown node as fence=Tentative d'enregistrer un nœud inconnu comme barrière
-Registered @1 and @2=Enregistrement de @1 et @
-[MOD] signs loaded=[MOD] signs chargé
+Unicode font=
+Wide font=
+Wooden Wall Sign=
+Steel Wall Sign=

--- a/locale/signs_lib.ms.tr
+++ b/locale/signs_lib.ms.tr
@@ -1,27 +1,12 @@
 # textdomain: signs_lib
 Locked sign, owned by @1@n=Papan tanda berkunci, milik @1@n
+Skims through all currently-loaded sign-bearing mapblocks, clears away any entities within each sign's node space, and regenerates their text entities, if any.=
+There are no signs in the currently-loaded terrain.=
+Found a total of @1 sign nodes across @2 blocks.=
+Regenerating sign entities ...=
+Finished.=
 Write=
-@1 wrote "@2" to sign at @3=
-@1 flipped the wide-font switch to "@2" at @3=
-@1 flipped the unicode-font switch to "@2" at @3=
-
-
-##### not used anymore #####
-
-locked =berkunci 
-@1 wrote "@2" to @3sign at @4=@1 menulis "@2" atas papan tanda @3dekat @4
-Sign=Papan Tanda
-Can edit all locked signs=Boleh sunting semua papan tanda berkunci
-Locked Sign=Papan Tanda Berkunci
-green=hijau
-yellow=kuning
-red=merah
-white_red=putih_merah
-white_black=putih_hitam
-orange=jingga
-blue=biru
-brown=perang
-Sign (@1, metal)=Papan Tanda (@1, logam)
-Attempt to register unknown node as fence=Cuba untuk mendaftar nod tidak diketahui sebagai pagar
-Registered @1 and @2=Telah daftar @1 dan @2
-[MOD] signs loaded=[MODS] signs telah dimuatkan
+Unicode font=
+Wide font=
+Wooden Wall Sign=
+Steel Wall Sign=

--- a/locale/signs_lib.ru.tr
+++ b/locale/signs_lib.ru.tr
@@ -1,27 +1,12 @@
 # textdomain: signs_lib
 Locked sign, owned by @1@n=защищенная табличка, пренадлежит @1@n
+Skims through all currently-loaded sign-bearing mapblocks, clears away any entities within each sign's node space, and regenerates their text entities, if any.=
+There are no signs in the currently-loaded terrain.=
+Found a total of @1 sign nodes across @2 blocks.=
+Regenerating sign entities ...=
+Finished.=
 Write=записать
-@1 wrote "@2" to sign at @3=
-@1 flipped the wide-font switch to "@2" at @3=
-@1 flipped the unicode-font switch to "@2" at @3=
-
-
-##### not used anymore #####
-
-locked =защищенный 
-@1 wrote "@2" to @3sign at @4=@1 записал "@2" в @3sign на @4
-Sign=табличка
-Can edit all locked signs=Может редактировать все защищенные таблички
-Locked Sign=защищенная табличка
-green=зеленая
-yellow=желтая
-red=красная
-white_red=краснобелая
-white_black=чернобелая
-orange=оранжевая
-blue=синея
-brown=коричневая
-Sign (@1, metal)=Табличка (@1, металл)
-Attempt to register unknown node as fence=Попытка зарегистрировать неизвестный узел как забор
-Registered @1 and @2=Зарегистрировано @1 для @2
-[MOD] signs loaded=[MOD] мод табличек загружен
+Unicode font=
+Wide font=
+Wooden Wall Sign=
+Steel Wall Sign=

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -1,6 +1,12 @@
 # textdomain: signs_lib
 Locked sign, owned by @1@n=
+Skims through all currently-loaded sign-bearing mapblocks, clears away any entities within each sign's node space, and regenerates their text entities, if any.=
+There are no signs in the currently-loaded terrain.=
+Found a total of @1 sign nodes across @2 blocks.=
+Regenerating sign entities ...=
+Finished.=
 Write=
-@1 wrote "@2" to sign at @3=
-@1 flipped the wide-font switch to "@2" at @3=
-@1 flipped the unicode-font switch to "@2" at @3=
+Unicode font=
+Wide font=
+Wooden Wall Sign=
+Steel Wall Sign=

--- a/standard_signs.lua
+++ b/standard_signs.lua
@@ -1,8 +1,10 @@
 -- Definitions for standard minetest_game wooden and steel wall signs
 
+local S = signs_lib.S
+
 if minetest.get_modpath("default") then
 	signs_lib.register_sign("default:sign_wall_wood", {
-		description = "Wooden wall sign",
+		description = S("Wooden Wall Sign"),
 		inventory_image = "signs_lib_sign_wall_wooden_inv.png",
 		tiles = {
 			"signs_lib_sign_wall_wooden.png",
@@ -20,7 +22,7 @@ if minetest.get_modpath("default") then
 	})
 
 	signs_lib.register_sign("default:sign_wall_steel", {
-		description = "Steel wall sign",
+		description = S("Steel Wall Sign"),
 		inventory_image = "signs_lib_sign_wall_steel_inv.png",
 		tiles = {
 			"signs_lib_sign_wall_steel.png",


### PR DESCRIPTION
This PR does the following:

- Mark a bunch of strings in this mod as translatable by adding the `S()`
- Update locale files
- Update German translation