### PR TITLE
add initial_properties

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -166,7 +166,6 @@ local ctexcache_wide = {}
 -- entity handling
 
 minetest.register_entity("signs_lib:text", {
-
 	initial_properties = {
 		collisionbox = { 0, 0, 0, 0, 0, 0 },
 		visual = "mesh",

--- a/api.lua
+++ b/api.lua
@@ -166,12 +166,15 @@ local ctexcache_wide = {}
 -- entity handling
 
 minetest.register_entity("signs_lib:text", {
-	collisionbox = { 0, 0, 0, 0, 0, 0 },
-	visual = "mesh",
-	mesh = "signs_lib_standard_sign_entity_wall.obj",
-	textures = {},
-	static_save = true,
-	backface_culling = false,
+
+	initial_properties = {
+		collisionbox = { 0, 0, 0, 0, 0, 0 },
+		visual = "mesh",
+		mesh = "signs_lib_standard_sign_entity_wall.obj",
+		textures = {},
+		static_save = true,
+		backface_culling = false,
+	},
 	on_activate = function(self)
 		local node = minetest.get_node(self.object:get_pos())
 		if minetest.get_item_group(node.name, "sign") == 0 then


### PR DESCRIPTION
Adds initial_properties update so that 5.7dev doesn't throw an error when entering text on signs.