### PR TITLE
Convert CR(LF)s to LFs

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -818,6 +818,9 @@ function signs_lib.update_sign(pos, fields)
 	local ownstr = ""
 	if owner ~= "" then ownstr = S("Locked sign, owned by @1\n", owner) end
 
+	-- Fix pasting from Windows: CR instead of LF
+	text = string.gsub(text, "\r\n?", "\n")
+
 	meta:set_string("text", text)
 	meta:set_string("infotext", ownstr..make_infotext(text).." ")
 


### PR DESCRIPTION
Windows clients paste texts with line breaks as CR (not CRLF). It's unknown whether this is the problem with copying the texts from Minetest or pasting them. This PR fixes this by converting every CR(LF) into LF on receiving fields.

This PR is ready for review.

<details>
<summary>Signs rendered with CRs</summary>

* Left: Display Modpack (mt-mods/display_modpack#19)
* Right: Signs lib

![screenshot_20240805_110018](https://github.com/user-attachments/assets/1dd4f4b1-d354-4728-8d93-75392f32e696)
</details>